### PR TITLE
hotfix: add flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+max-complexity = 15
+select = C, E, W, F
+ignore = C101, C407, C408, E127, E203, E402, E731, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
         args: ["--allow-missing-credentials"]
       - id: detect-private-key
       - id: end-of-file-fixer
-      - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
     rev: 23.12.1


### PR DESCRIPTION
Fix flake8 check in pre-commit raise conflict with isort when commit (different line-length config)