### PR TITLE
hotfix: change isort to check before black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,19 +19,19 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-        name: PEP8 formatting
-        args: [ --skip-string-normalization]
-
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
       - id: isort
         name: I-sort imports
         args: ["--profile", "black"]
+
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        name: PEP8 formatting
+        args: [ --skip-string-normalization]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0


### PR DESCRIPTION
isort can handle the import sorting first, and then black can format the rest of the code